### PR TITLE
Update Basque Verb-Index link

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
         <li><a href="https://verbs.colorado.edu/propbank/framesets-arabic/">Arabic Propbank</a></li>
         <li><a href="http://turkunlp.github.io/Finnish_PropBank/">Finnish Propbank</a></li>       
 	<li><a href="http://www.nilc.icmc.usp.br/portlex/index.php/en/projects/propbankbringl">Portuguese Propbank</a></li>        
-        <li><a href="http://ixa2.si.ehu.es/e-rolda/en/bvi.php">Basque Verb-Index</a></li>
+        <li><a href="https://ixa2.si.ehu.eus/e-rolda/aditz_zerrenda.php">Basque Verb-Index</a></li>
 	<li><a href="https://turkishpropbank.github.io/">Turkish Propbank</a></li>        
         
         </p>


### PR DESCRIPTION
The [old link](http://ixa2.si.ehu.es/e-rolda/en/bvi.php) does not longer exist. Update it with this [other one](https://ixa2.si.ehu.eus/e-rolda/aditz_zerrenda.php).